### PR TITLE
Moved react-native-video and react-native-keep-awake as peer dependen…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -2,12 +2,10 @@
   "name": "react-native-af-video-player",
   "version": "0.2.1",
   "dependencies": {
-    "react-native-keep-awake": "^2.0.6",
     "react-native-linear-gradient": "2.3.0",
     "react-native-orientation": "^3.1.0",
     "react-native-slider": "https://github.com/abbasfreestyle/react-native-slider.git",
     "react-native-vector-icons": "^4.4.2",
-    "react-native-video": "^2.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
@@ -16,6 +14,10 @@
     "babel-preset-react-native": "4.0.0",
     "jest": "21.2.1",
     "react-test-renderer": "16.0.0-beta.5"
+  },
+  "peerDependencies": {
+    "react-native-keep-awake": "*",
+    "react-native-video": "*"
   },
   "description": "A customisable React Native video player for Android and IOS",
   "homepage": "https://github.com/abbasfreestyle/react-native-af-video-player#readme",


### PR DESCRIPTION
…cies. This was done for react-native version compatibility that these 2 dependencies need to be a newer version.